### PR TITLE
feat: add user info retrieval and authentication check endpoints; upd…

### DIFF
--- a/src/main/java/com/example/demo/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/demo/global/auth/OAuth2SuccessHandler.java
@@ -43,8 +43,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         cookie.setPath("/");
         cookie.setMaxAge(JwtProperties.EXPIRATION_TIME / 1000);
         response.addCookie(cookie);
-          log.info("JWT cookie set, redirecting to /api/users/home");
-        // Redirect to secured test page
-        response.sendRedirect("/api/users/home");
+        
+        // 프론트엔드로 리다이렉트 (토큰은 쿠키에 포함됨)
+        String frontendUrl = "https://cheerup-omega.vercel.app/home"; // 프론트엔드 성공 페이지 URL
+        log.info("Redirecting to frontend: {}", frontendUrl);
+        response.sendRedirect(frontendUrl);
     }
 }

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> httpBasic.disable())            .oauth2Login(oauth2 -> oauth2
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler((req, res, ex) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
@@ -88,12 +89,14 @@ public class SecurityConfig {
                                 "/api/users/oauth2/naver",
                                 "/api/users/oauth2/kakao",
                                 "/api/users/logout",
+                                "/api/users/check-auth",  // 로그인 상태 확인 API 허용
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/webjars/swagger-ui/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                );        return http.build();
+                );
+        return http.build();
     }
 }


### PR DESCRIPTION
## 🚀 백엔드-프론트엔드 연동을 위한 변경사항

### 1. **OAuth2SuccessHandler 수정**
- **변경 전**: 로그인 성공 시 `/api/users/home`으로 리다이렉트
- **변경 후**: 프론트엔드 성공 페이지(`http://localhost:5173/auth/success`)로 리다이렉트
- JWT 토큰은 여전히 HttpOnly 쿠키로 설정되어 보안 유지

### 2. **새로운 API 엔드포인트 추가**
프론트엔드에서 사용할 수 있는 JSON API들을 추가했습니다:

#### **`GET /api/users/me`** - 현재 사용자 정보 조회
```json
{
  "success": true,
  "message": "사용자 정보 조회 성공",
  "data": {
    "id": 1,
    "email": "user@example.com",
    "username": "사용자명",
    "provider": "google",
    "role": "ROLE_USER"
  }
}
```

#### **`GET /api/users/check-auth`** - 로그인 상태 확인
```json
{
  "authenticated": true,
  "user": {
    "id": 1,
    "email": "user@example.com",
    "username": "사용자명",
    "provider": "google"
  }
}
```

#### **`POST /api/users/api-logout`** - 로그아웃 (JSON 응답)
```json
{
  "success": true,
  "message": "로그아웃이 완료되었습니다."
}
```

### 3. **SecurityConfig 업데이트**
- `/api/users/check-auth` 엔드포인트를 인증 없이 접근 가능하도록 설정
- 기존 CORS 설정 유지 (프론트엔드 `localhost:5173` 허용)

## 🎯 프론트엔드에서 사용하는 방법

### 1. **OAuth2 소셜 로그인**
프론트엔드에서 소셜 로그인 버튼을 클릭하면:
```javascript
// 소셜 로그인 페이지로 리다이렉트
window.location.href = 'https://api.cheer-up.net/oauth2/authorization/google';
// 또는 'https://api.cheer-up.net/oauth2/authorization/naver';
// 또는 'https://api.cheer-up.net/oauth2/authorization/kakao';
```

### 2. **로그인 성공 후 처리**
프론트엔드에서 `/auth/success` 페이지를 만들어 처리:
```javascript
// /auth/success 페이지에서
useEffect(() => {
  // 로그인 상태 확인
  fetch('https://api.cheer-up.net/api/users/check-auth', {
    credentials: 'include' // 쿠키 포함
  })
  .then(res => res.json())
  .then(data => {
    if (data.authenticated) {
      // 로그인 성공 - 메인 페이지로 이동
      navigate('/dashboard');
    }
  });
}, []);
```

### 3. **사용자 정보 조회**
```javascript
// 현재 사용자 정보 가져오기
const getUserInfo = async () => {
  const response = await fetch('https://api.cheer-up.net/api/users/me', {
    credentials: 'include'
  });
  const data = await response.json();
  return data;
};
```

### 4. **로그아웃**
```javascript
// 로그아웃
const logout = async () => {
  await fetch('https://api.cheer-up.net/api/users/api-logout', {
    method: 'POST',
    credentials: 'include'
  });
  // 로그인 페이지로 이동
  navigate('/login');
};
```

### 5. **API 요청 시 인증**
다른 보호된 API를 호출할 때:
```javascript
// 모든 API 요청에 credentials: 'include' 추가
fetch('https://api.cheer-up.net/api/stories', {
  credentials: 'include' // JWT 쿠키 자동 포함
})
```